### PR TITLE
Fix order reducer import typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,14 +8,14 @@ import './index.css';
 import * as serviceWorker from './serviceWorker';
 import burgerBuilderReducer from './store/reducers/burgerBuilder';
 import thunk from 'redux-thunk'
-import oderReducers from './store/reducers/order';
+import orderReducer from './store/reducers/order';
 import authReducer from './store/reducers/auth';
 
 const composeEnhancers = process.env.NODE_ENV === 'development' ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ : null || compose;
 
 const rootReducer = combineReducers({
   burgerBuilder: burgerBuilderReducer,
-  order: oderReducers,
+  order: orderReducer,
   auth: authReducer
 })
 


### PR DESCRIPTION
## Summary
- fix typo in order reducer import in index.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68484fe8674883318a299203763059ad